### PR TITLE
add functionallity to activate/deactivate the application form

### DIFF
--- a/frontend/src/components/BackendTest/BackendTest.css
+++ b/frontend/src/components/BackendTest/BackendTest.css
@@ -1,0 +1,52 @@
+a.backend-test-container {
+    background-color: #f9f9f9;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    padding: 1.5rem;
+    margin: 2rem 0;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+
+.backend-test-container h2 {
+    margin-top: 0;
+    color: #333;
+}
+
+.backend-test-container p {
+    color: #555;
+}
+
+.backend-test-container button {
+    background-color: #007bff;
+    color: white;
+    border: none;
+    padding: 10px 15px;
+    border-radius: 5px;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+.backend-test-container button:hover {
+    background-color: #0056b3;
+}
+
+.response-output {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 5px;
+    font-family: monospace;
+    word-break: break-all;
+}
+
+.response-output.success {
+    background-color: #e8f5e9;
+    color: #2e7d32;
+    border: 1px solid #a5d6a7;
+}
+
+.response-output.error {
+    background-color: #ffebee;
+    color: #c62828;
+    border: 1px solid #ef9a9a;
+}

--- a/frontend/src/pages/Apply/Apply.tsx
+++ b/frontend/src/pages/Apply/Apply.tsx
@@ -5,6 +5,8 @@ import './Apply.css';
 
 const Apply = () => {
     const [activeTab, setActiveTab] = useState('General');
+    const applicationsOpen = false; // Change to true when applications are open
+
 
     return (
         <>
@@ -12,70 +14,80 @@ const Apply = () => {
             <div className="apply-container">
                 <div className="apply-content">
                     <h2>Apply to KTH Aero Design</h2>
-                    <p>Pick what you're applying for and fill out the corresponding form.</p>
-                    <div className="tabs">
-                        <button
-                            className={activeTab === 'General' ? 'active' : ''}
-                            onClick={() => setActiveTab('General')}>
-                            General
-                        </button>
-                        <button
-                            className={activeTab === 'PR Team' ? 'active' : ''}
-                            onClick={() => setActiveTab('PR Team')}>
-                            PR Team
-                        </button>
-                    </div>
-                    {/* Google Forms baserat på activeTab */}
-                    <div className="form-area">
-                        {activeTab === 'General' && (
-                            <div className="form-panel">
-                                <div className="form-embed">
-                                    <iframe
-                                        src="https://docs.google.com/forms/d/e/1FAIpQLSesTrVxWbkJ7Hyi6uf0UY-Nvlzb5H98yuBXm7PWrSTOtP5yjw/viewform?embedded=true"
-                                        title="General Application Form"
-                                        loading="lazy"
-                                        frameBorder="0"
-                                        marginHeight={0}
-                                        marginWidth={0}>
-                                        Loading…
-                                    </iframe>
-                                </div>
-                                <p className="form-alt">
-                                    Prefer a new tab?
-                                    <a
-                                        href="https://docs.google.com/forms/d/e/1FAIpQLSesTrVxWbkJ7Hyi6uf0UY-Nvlzb5H98yuBXm7PWrSTOtP5yjw/viewform"
-                                        target="_blank"
-                                        rel="noopener">
-                                        Open form ↗
-                                    </a>
-                                </p>
+                    {applicationsOpen ? (
+                        <>
+                            <p>Pick what you're applying for and fill out the corresponding form.</p>
+
+
+                            <div className="tabs">
+                                <button
+                                    className={activeTab === 'General' ? 'active' : ''}
+                                    onClick={() => setActiveTab('General')}>
+                                    General
+                                </button>
+                                <button
+                                    className={activeTab === 'PR Team' ? 'active' : ''}
+                                    onClick={() => setActiveTab('PR Team')}>
+                                    PR Team
+                                </button>
                             </div>
-                        )}
-                        {activeTab === 'PR Team' && (
-                            <div className="form-panel">
-                                <div className="form-embed">
-                                    <iframe
-                                        src="https://docs.google.com/forms/d/e/1FAIpQLScEzUVLnxHQQBNwZLt4M6NWDn4aD3NAn2tTrbQZ7qNdmpugGg/viewform?embedded=true"
-                                        title="PR Team Application Form"
-                                        loading="lazy"
-                                        frameBorder="0"
-                                        marginHeight={0}
-                                        marginWidth={0}>
-                                        Loading…
-                                    </iframe>
-                                </div>
-                                <p className="form-alt">
-                                    Prefer a new tab?
-                                    <a
-                                        href="https://docs.google.com/forms/d/e/1FAIpQLScEzUVLnxHQQBNwZLt4M6NWDn4aD3NAn2tTrbQZ7qNdmpugGg/viewform"
-                                        target="_blank"
-                                        rel="noopener">
-                                        Open form ↗
-                                    </a>
-                                </p>
+                            {/* Google Forms baserat på activeTab */}
+                            <div className="form-area">
+                                {activeTab === 'General' && (
+                                    <div className="form-panel">
+                                        <div className="form-embed">
+                                            <iframe
+                                                src="https://docs.google.com/forms/d/e/1FAIpQLSesTrVxWbkJ7Hyi6uf0UY-Nvlzb5H98yuBXm7PWrSTOtP5yjw/viewform?embedded=true"
+                                                title="General Application Form"
+                                                loading="lazy"
+                                                frameBorder="0"
+                                                marginHeight={0}
+                                                marginWidth={0}>
+                                                Loading…
+                                            </iframe>
+                                        </div>
+                                        <p className="form-alt">
+                                            Prefer a new tab?
+                                            <a
+                                                href="https://docs.google.com/forms/d/e/1FAIpQLSesTrVxWbkJ7Hyi6uf0UY-Nvlzb5H98yuBXm7PWrSTOtP5yjw/viewform"
+                                                target="_blank"
+                                                rel="noopener">
+                                                Open form ↗
+                                            </a>
+                                        </p>
+                                    </div>
+                                )}
+                                {activeTab === 'PR Team' && (
+                                    <div className="form-panel">
+                                        <div className="form-embed">
+                                            <iframe
+                                                src="https://docs.google.com/forms/d/e/1FAIpQLScEzUVLnxHQQBNwZLt4M6NWDn4aD3NAn2tTrbQZ7qNdmpugGg/viewform?embedded=true"
+                                                title="PR Team Application Form"
+                                                loading="lazy"
+                                                frameBorder="0"
+                                                marginHeight={0}
+                                                marginWidth={0}>
+                                                Loading…
+                                            </iframe>
+                                        </div>
+                                        <p className="form-alt">
+                                            Prefer a new tab?
+                                            <a
+                                                href="https://docs.google.com/forms/d/e/1FAIpQLScEzUVLnxHQQBNwZLt4M6NWDn4aD3NAn2tTrbQZ7qNdmpugGg/viewform"
+                                                target="_blank"
+                                                rel="noopener">
+                                                Open form ↗
+                                            </a>
+                                        </p>
+                                    </div>
+                                )}
                             </div>
-                        )}
-                    </div>
+                        </>
+                    ) : (
+                        <p style={{ marginTop: '2rem', fontSize: '1.2rem' }}>
+                            We are currently not accepting applications. Please check back later! <br></br> The form re-opens February 15.
+                        </p>
+                    )}
                 </div>
             </div>
             <Footer />


### PR DESCRIPTION
This pull request introduces a conditional display for the application form and improves the styling of the backend test component. The main change is that the application form on the `Apply` page will only be shown when applications are open; otherwise, a message is displayed to users. Additionally, new CSS styles have been added to enhance the visual appearance of the backend test component.

**Apply page logic update:**

* Added the `applicationsOpen` flag to `Apply.tsx` to control whether the application form or a "not accepting applications" message is displayed. [[1]](diffhunk://#diff-4401b7396bf42e1ae5b84934c004d8653b896aec6acd63f4f6d18e3545a57366R8-R21) [[2]](diffhunk://#diff-4401b7396bf42e1ae5b84934c004d8653b896aec6acd63f4f6d18e3545a57366R85-R90)

**Styling improvements:**

* Created new CSS rules in `BackendTest.css` to style the backend test container, its elements, and response outputs for success and error states.